### PR TITLE
Drop compilation of ffmpeg osg plugin and ffmpeg dependency

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -16,8 +16,6 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 expat:
 - '2'
-ffmpeg:
-- '6'
 fontconfig:
 - '2'
 freetype:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '16'
 expat:
 - '2'
-ffmpeg:
-- '6'
 fontconfig:
 - '2'
 freetype:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -16,8 +16,6 @@ cxx_compiler_version:
 - '16'
 expat:
 - '2'
-ffmpeg:
-- '6'
 fontconfig:
 - '2'
 freetype:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -8,8 +8,6 @@ cxx_compiler:
 - vs2019
 expat:
 - '2'
-ffmpeg:
-- '6'
 fontconfig:
 - '2'
 freetype:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - fix_tiff_link.patch
 
 build:
-  number: 19
+  number: 20
   skip: true  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
@@ -45,9 +45,6 @@ requirements:
     - libtiff
     - libcurl
     - libpng
-    - ffmpeg 4.4
-    # See https://github.com/conda-forge/openscenegraph-feedstock/pull/31
-    # And https://github.com/conda-forge/ffmpeg-feedstock/pull/214 
     - fontconfig
     - collada-dom
     - xcb-util                           # [linux]
@@ -72,7 +69,6 @@ requirements:
     - libtiff
     - libcurl
     - libpng
-    - ffmpeg
     - fontconfig
     - collada-dom
     - libxcb                             # [linux]


### PR DESCRIPTION
No one is actually using the ffmpeg osg plugin (see https://github.com/Gepetto/gepetto-viewer/issues/226), so we can drop it to simplify support of new version of ffmpeg. Similar to what was done in Debian/Ubuntu in https://git.launchpad.net/ubuntu/+source/openscenegraph/commit/?h=ubuntu/noble&id=a453c15270e96863f6c174c2ad1f6bf08e917111 .

Fix https://github.com/conda-forge/openscenegraph-feedstock/issues/29 .
Fix https://github.com/conda-forge/openscenegraph-feedstock/pull/41 .
Fix https://github.com/conda-forge/openscenegraph-feedstock/pull/36 .
Fix https://github.com/conda-forge/openscenegraph-feedstock/pull/34 .

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
